### PR TITLE
[add] 메인메뉴 C++ 클래스 생성 및 블루프린트의 부모 클래스 변경

### DIFF
--- a/SSBProject/Config/DefaultEngine.ini
+++ b/SSBProject/Config/DefaultEngine.ini
@@ -2,6 +2,7 @@
 
 [/Script/EngineSettings.GameMapsSettings]
 GameDefaultMap=/Engine/Maps/Templates/OpenWorld
+EditorStartupMap=/Game/Maps/MainMenuMap.MainMenuMap
 
 [/Script/Engine.RendererSettings]
 r.AllowStaticLighting=False

--- a/SSBProject/Content/Blueprints/GameModes/BP_MainMenuGameMode.uasset
+++ b/SSBProject/Content/Blueprints/GameModes/BP_MainMenuGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:10f437d9eec9be348209e6151a7c7226aec9433a707261278eec85faa4d498c3
-size 20882
+oid sha256:9df85a51da5e760a946e8a18c58d720137be1b1a2b0e37af7db3f2a623e78553
+size 21369

--- a/SSBProject/Content/Blueprints/GameStates/BP_MainMenuGameState.uasset
+++ b/SSBProject/Content/Blueprints/GameStates/BP_MainMenuGameState.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b10809bfb6c2b2f74167ea57035706e2900fbe4eac8993bd0a88b234882cf5b7
-size 20303
+oid sha256:d8b0b4f42054e434e656e10e14dd2509efd99880f8c596ce45582815103dfc35
+size 20790

--- a/SSBProject/Content/Blueprints/PlayerControllers/BP_MainMenuPlayerController.uasset
+++ b/SSBProject/Content/Blueprints/PlayerControllers/BP_MainMenuPlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e0fb36788fb5369ecdc05b269910e11ae1e5521b7b3c7229fe674e65bdc8e3ff
-size 19798
+oid sha256:1f95dd19311b8bb59769ee4f153d04751d62c90b5c7e0a221d9237509e538774
+size 20313

--- a/SSBProject/Content/Blueprints/PlayerStates/BP_MainMenuPlayerState.uasset
+++ b/SSBProject/Content/Blueprints/PlayerStates/BP_MainMenuPlayerState.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:13c50ec5705c9b39a01df4cde3be675984967f00acc2bd0394de38ead726ec3a
-size 20375
+oid sha256:28b37846286e7830443650fa286e97fad0d716c8286178a5f79c9c0a1a60f89e
+size 20862

--- a/SSBProject/Content/Blueprints/UserWidgets/WBP_MainMenuHUD.uasset
+++ b/SSBProject/Content/Blueprints/UserWidgets/WBP_MainMenuHUD.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:03a3eb73f57c2bf96ec78bc2a84183ea44ebaa47317b8d5a653d5537262dfed1
-size 19522
+oid sha256:8bdd0af0ba4a8ffd60980872deddb41e80a322654adc6b9badf4b78ee752dae8
+size 22834

--- a/SSBProject/SSBProject.uproject
+++ b/SSBProject/SSBProject.uproject
@@ -9,7 +9,8 @@
 			"Type": "Runtime",
 			"LoadingPhase": "Default",
 			"AdditionalDependencies": [
-				"Engine"
+				"Engine",
+				"UMG"
 			]
 		}
 	],

--- a/SSBProject/Source/SSBProject/GameModes/MainMenuGameMode.cpp
+++ b/SSBProject/Source/SSBProject/GameModes/MainMenuGameMode.cpp
@@ -1,0 +1,8 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "MainMenuGameMode.h"
+
+
+
+

--- a/SSBProject/Source/SSBProject/GameModes/MainMenuGameMode.h
+++ b/SSBProject/Source/SSBProject/GameModes/MainMenuGameMode.h
@@ -1,0 +1,20 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameMode.h"
+#include "MainMenuGameMode.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class SSBPROJECT_API AMainMenuGameMode : public AGameMode
+{
+	GENERATED_BODY()
+	
+	
+	
+	
+};

--- a/SSBProject/Source/SSBProject/GameStates/MainMenuGameState.cpp
+++ b/SSBProject/Source/SSBProject/GameStates/MainMenuGameState.cpp
@@ -1,0 +1,8 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "MainMenuGameState.h"
+
+
+
+

--- a/SSBProject/Source/SSBProject/GameStates/MainMenuGameState.h
+++ b/SSBProject/Source/SSBProject/GameStates/MainMenuGameState.h
@@ -1,0 +1,20 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameState.h"
+#include "MainMenuGameState.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class SSBPROJECT_API AMainMenuGameState : public AGameState
+{
+	GENERATED_BODY()
+	
+	
+	
+	
+};

--- a/SSBProject/Source/SSBProject/PlayerControllers/MainMenuPlayerController.cpp
+++ b/SSBProject/Source/SSBProject/PlayerControllers/MainMenuPlayerController.cpp
@@ -1,0 +1,8 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "MainMenuPlayerController.h"
+
+
+
+

--- a/SSBProject/Source/SSBProject/PlayerControllers/MainMenuPlayerController.h
+++ b/SSBProject/Source/SSBProject/PlayerControllers/MainMenuPlayerController.h
@@ -1,0 +1,20 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/PlayerController.h"
+#include "MainMenuPlayerController.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class SSBPROJECT_API AMainMenuPlayerController : public APlayerController
+{
+	GENERATED_BODY()
+	
+	
+	
+	
+};

--- a/SSBProject/Source/SSBProject/PlayerStates/MainMenuPlayerState.cpp
+++ b/SSBProject/Source/SSBProject/PlayerStates/MainMenuPlayerState.cpp
@@ -1,0 +1,8 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "MainMenuPlayerState.h"
+
+
+
+

--- a/SSBProject/Source/SSBProject/PlayerStates/MainMenuPlayerState.h
+++ b/SSBProject/Source/SSBProject/PlayerStates/MainMenuPlayerState.h
@@ -1,0 +1,20 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/PlayerState.h"
+#include "MainMenuPlayerState.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class SSBPROJECT_API AMainMenuPlayerState : public APlayerState
+{
+	GENERATED_BODY()
+	
+	
+	
+	
+};

--- a/SSBProject/Source/SSBProject/SSBProject.Build.cs
+++ b/SSBProject/Source/SSBProject/SSBProject.Build.cs
@@ -1,14 +1,23 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
 using UnrealBuildTool;
+using System.IO;
 
 public class SSBProject : ModuleRules
 {
 	public SSBProject(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-	
-		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput" });
+
+		PublicIncludePaths.AddRange(new string[] {
+			Path.Combine(ModuleDirectory, "GameModes"),
+			Path.Combine(ModuleDirectory, "GameStates"),
+			Path.Combine(ModuleDirectory, "PlayerControllers"),
+			Path.Combine(ModuleDirectory, "PlayerStates"),
+			Path.Combine(ModuleDirectory, "UserWidgets"),
+		});
+
+		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "UMG" });
 
 		PrivateDependencyModuleNames.AddRange(new string[] {  });
 

--- a/SSBProject/Source/SSBProject/UserWidgets/MainMenuHUD.cpp
+++ b/SSBProject/Source/SSBProject/UserWidgets/MainMenuHUD.cpp
@@ -1,0 +1,8 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "MainMenuHUD.h"
+
+
+
+

--- a/SSBProject/Source/SSBProject/UserWidgets/MainMenuHUD.h
+++ b/SSBProject/Source/SSBProject/UserWidgets/MainMenuHUD.h
@@ -1,0 +1,20 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "MainMenuHUD.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class SSBPROJECT_API UMainMenuHUD : public UUserWidget
+{
+	GENERATED_BODY()
+	
+	
+	
+	
+};


### PR DESCRIPTION
메인메뉴 C++ 클래스 생성

- 메인메뉴 게임모드
- 메인메뉴 게임스테이트
- 메인메뉴 플레이어컨트롤러
- 메인메뉴 플레이어스테이트
- 메인메뉴 허드

C++ 클래스의 폴더 경로에 대한 PublicIncludePaths 설정

기존 블루프린트 클래스의 부모 클래스 변경

- 메인메뉴 게임모드
- 메인메뉴 게임스테이트
- 메인메뉴 플레이어컨트롤러
- 메인메뉴 플레이어스테이트
- 메인메뉴 허드

에디어 시작맵을 MainMenuMap으로 설정