### PR TITLE
[fix] 플레이어 캐릭터들이 동시에 스폰되어 동시에 게임이 시작될 수 있도록 수정

### DIFF
--- a/SSBProject/Source/SSBProject/GameModes/FighterGamemode.cpp
+++ b/SSBProject/Source/SSBProject/GameModes/FighterGamemode.cpp
@@ -53,34 +53,65 @@ void AFighterGamemode::HandlePlayerCharacterClass(APlayerController* Player, TSu
 {
     CharacterClassMap.FindOrAdd(Player) = CharacterClass;
 
-    AFighterPlayerState* FighterPlayerState = Cast<AFighterPlayerState>(Player->PlayerState);
+    AFighterGameState* FighterGameState = GetGameState<AFighterGameState>();
 
-    // 바로 스폰 시도 가능 (이미 로그인된 경우)
-    if (CharacterClass && Player && !Player->GetPawn() && FighterPlayerState)
+    int32 TotalPlayerCount = FighterGameState->GetTotalPlayerCount();
+    int32 PlayerJoinCount = FighterGameState->GetPlayerJoinCount();
+
+    if (TotalPlayerCount == PlayerJoinCount)
     {
-        // 플레이어가 스폰되어야할 위치를 가진 액터들
-        TArray<AActor*> FoundActors;
-        UGameplayStatics::GetAllActorsOfClass(GetWorld(), ASpawnPointActor::StaticClass(), FoundActors);
+        SpawnPlayerCharacters();
+    }
+}
 
-        // 플레이어가 스폰되어야할 위치를 위해 인덱스를 가져옴
-        int32 PlayerIndex = FighterPlayerState->GetPlayerIndex();
+void AFighterGamemode::SpawnPlayerCharacters()
+{
+    // Pawn들의 BeginPlay이벤트가 차례대로 호출되고 플레이어 컨트롤러들의 OnPossecc 이벤트가 따로 한번에 호출 될 수 있도록 분리
+    TMap<APlayerController*, TObjectPtr<APawn>> SpawnCharacter;
 
-        FVector SpawnLocation = FVector(0.f, 0.f, 0.f);
-        FRotator SpawnRotation = FRotator::ZeroRotator;
+    // 플레이어가 빙의 될 폰 스폰하기
+    for (auto e : CharacterClassMap)
+    {
+        APlayerController* Player = e.Key;
+        TSubclassOf<APawn> CharacterClass = e.Value;
 
-        if (FoundActors.Num() > PlayerIndex)
+        AFighterPlayerState* FighterPlayerState = Cast<AFighterPlayerState>(Player->PlayerState);
+
+        // 바로 스폰 시도 가능 (이미 로그인된 경우)
+        if (CharacterClass && Player && !Player->GetPawn() && FighterPlayerState)
         {
-            SpawnLocation = FoundActors[PlayerIndex]->GetActorLocation();
-            SpawnRotation = FoundActors[PlayerIndex]->GetActorRotation();
+            // 플레이어가 스폰되어야할 위치를 가진 액터들
+            TArray<AActor*> FoundActors;
+            UGameplayStatics::GetAllActorsOfClass(GetWorld(), ASpawnPointActor::StaticClass(), FoundActors);
+
+            // 플레이어가 스폰되어야할 위치를 위해 인덱스를 가져옴
+            int32 PlayerIndex = FighterPlayerState->GetPlayerIndex();
+
+            FVector SpawnLocation = FVector(0.f, 0.f, 0.f);
+            FRotator SpawnRotation = FRotator::ZeroRotator;
+
+            if (FoundActors.Num() > PlayerIndex)
+            {
+                SpawnLocation = FoundActors[PlayerIndex]->GetActorLocation();
+                SpawnRotation = FoundActors[PlayerIndex]->GetActorRotation();
+            }
+
+            FActorSpawnParameters SpawnParams;
+            SpawnParams.Owner = Player;
+
+            APawn* NewPawn = GetWorld()->SpawnActor<APawn>(*CharacterClass, SpawnLocation, SpawnRotation, SpawnParams);
+            SpawnCharacter.Add(Player, NewPawn);
         }
+    }
 
-        FActorSpawnParameters SpawnParams;
-        SpawnParams.Owner = Player;
+    for (auto e : SpawnCharacter)
+    {
+        APlayerController* CurPlayerController = e.Key;
+        TObjectPtr<APawn> CurPawn = e.Value;
 
-        APawn* NewPawn = GetWorld()->SpawnActor<APawn>(*CharacterClass, SpawnLocation, SpawnRotation, SpawnParams);
-        if (NewPawn)
+        if (CurPlayerController && CurPawn)
         {
-            Player->Possess(NewPawn);
+            CurPlayerController->Possess(CurPawn);
         }
     }
 }

--- a/SSBProject/Source/SSBProject/GameModes/FighterGamemode.h
+++ b/SSBProject/Source/SSBProject/GameModes/FighterGamemode.h
@@ -27,5 +27,8 @@ public:
 	void HandlePlayerCharacterClass(APlayerController* Player, TSubclassOf<APawn> CharacterClass);
 
 private:
+	void SpawnPlayerCharacters();
+
+private:
 	TMap<APlayerController*, TSubclassOf<APawn>> CharacterClassMap;
 };


### PR DESCRIPTION
- HandlePlayerCharacterClass 함수에서는 플레이어 컨트롤러가 스폰시키려고 하는 캐릭터 클래스만 받고 스폰 로직은 별도의 함수로 분리

- void SpawnPlayerCharacters() 함수 추가
  - 해당 함수에서 플레이어 컨트롤러가 빙의할 폰 스폰 및 모든 폰이 스폰된 후 빙의되도록 수정