### PR TITLE
[fix] 타이틀에서 맵 이동시 서버와 연결이 끊기지 않게 ServerTravel 사용

### DIFF
--- a/SSBProject/Source/SSBProject/PlayerControllers/TitleWidgetController.cpp
+++ b/SSBProject/Source/SSBProject/PlayerControllers/TitleWidgetController.cpp
@@ -30,6 +30,16 @@ void ATitleWidgetController::BeginPlay()
 	}
 }
 
+void ATitleWidgetController::ServerRequestMainMenuTravel_Implementation(APlayerController* TargetPlayer)
+{
+	GetWorld()->ServerTravel(TEXT("/Game/Maps/MainMenuMap"), TRAVEL_Absolute);
+
+	//if (TargetPlayer)
+	//{
+	//	TargetPlayer->ClientTravel(TEXT("/Game/Maps/MainMenuMap"), TRAVEL_Absolute);
+	//}
+}
+
 void ATitleWidgetController::SetTitleCameraView()
 {
 	TArray<AActor*> FoundCameras;

--- a/SSBProject/Source/SSBProject/PlayerControllers/TitleWidgetController.h
+++ b/SSBProject/Source/SSBProject/PlayerControllers/TitleWidgetController.h
@@ -12,6 +12,9 @@ class SSBPROJECT_API ATitleWidgetController : public APlayerController
 public:
 	virtual void BeginPlay() override;
 
+	UFUNCTION(Server, Reliable)
+	void ServerRequestMainMenuTravel(APlayerController* TargetPlayer);
+
 private:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = APlayerController, Meta = (AllowPrivateAccess))
 	TSubclassOf<UUserWidget> UIWidgetClass;

--- a/SSBProject/Source/SSBProject/UserWidgets/TitleUserWidget.cpp
+++ b/SSBProject/Source/SSBProject/UserWidgets/TitleUserWidget.cpp
@@ -1,5 +1,6 @@
 #include "TitleUserWidget.h"
 #include "Kismet/GameplayStatics.h"
+#include "TitleWidgetController.h"
 
 UTitleUserWidget::UTitleUserWidget(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
@@ -24,6 +25,13 @@ void UTitleUserWidget::NativeConstruct()
 FReply UTitleUserWidget::NativeOnKeyDown(const FGeometry& InGeometry, const FKeyEvent& InKeyEvent)
 {
 	// 아무 키나 누르면 다음 레벨로 이동
-	UGameplayStatics::OpenLevel(GetWorld(), TEXT("MainMenuMap"));
+	//UGameplayStatics::OpenLevel(GetWorld(), TEXT("MainMenuMap"));
+
+	ATitleWidgetController* PlayerController = GetOwningPlayer<ATitleWidgetController>();
+	if (PlayerController)
+	{
+		PlayerController->ServerRequestMainMenuTravel(PlayerController);
+	}
+
 	return FReply::Handled();
 }


### PR DESCRIPTION
타이틀에서 맵 이동시 ServerTravel을 사용해서 맵 이동
ServerTravel을 사용했기 때문에 모든 클라이언트가 동시에 이동합니다.

ClientTravel을 사용하고자 했지만, ClientTravel을 사용시 서버와 연결이 끊긴다는 문제가 있고, 해결 방법을 찾지 못해 일단 ServerTravel 사용했습니다.